### PR TITLE
Update memory parameter with correct entry

### DIFF
--- a/aws/fargate.yml
+++ b/aws/fargate.yml
@@ -54,8 +54,8 @@ Parameters:
 
   Memory:
     Description: The memory reservation for the container. Must adhere to https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html.
-    Type: String
-    Default: 2GB
+    Type: Number
+    Default: 2048
 
   JvmOpts:
     Description: The JVM options passed to prisma. For example, change this value when changing the memory parameter. Max heap memory (Xmx) should be roughly two thirds of the total memory.


### PR DESCRIPTION
Fixed the memory parameter. Wasn't a valid configuration.

See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html

While this change did allow me to create the service successfully. It still wasn't available (got a 503 error that the service wasn't available). Baby steps.