### PR TITLE
Remove potentially unused ECSRole from fargate template

### DIFF
--- a/aws/fargate.yml
+++ b/aws/fargate.yml
@@ -312,45 +312,6 @@ Resources:
             - !Ref PublicSubnetOne
             - !Ref PublicSubnetTwo
 
-  # This is an IAM role which authorizes ECS to manage resources on your
-  # account on your behalf, such as updating your load balancer with the
-  # details of where your containers are, so that traffic can reach your
-  # containers.
-  ECSRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service: [ecs.amazonaws.com]
-          Action: ['sts:AssumeRole']
-      Path: /
-      Policies:
-      - PolicyName: ecs-service
-        PolicyDocument:
-          Statement:
-          - Effect: Allow
-            Action:
-              # Rules which allow ECS to attach network interfaces to instances
-              # on your behalf in order for awsvpc networking mode to work right
-              - 'ec2:AttachNetworkInterface'
-              - 'ec2:CreateNetworkInterface'
-              - 'ec2:CreateNetworkInterfacePermission'
-              - 'ec2:DeleteNetworkInterface'
-              - 'ec2:DeleteNetworkInterfacePermission'
-              - 'ec2:Describe*'
-              - 'ec2:DetachNetworkInterface'
-
-              # Rules which allow ECS to update load balancers on your behalf
-              # with the information sabout how to send traffic to your containers
-              - 'elasticloadbalancing:DeregisterInstancesFromLoadBalancer'
-              - 'elasticloadbalancing:DeregisterTargets'
-              - 'elasticloadbalancing:Describe*'
-              - 'elasticloadbalancing:RegisterInstancesWithLoadBalancer'
-              - 'elasticloadbalancing:RegisterTargets'
-            Resource: '*'
-
   # This is a role which is used by the ECS tasks themselves.
   ECSTaskExecutionRole:
     Type: AWS::IAM::Role
@@ -394,12 +355,6 @@ Outputs:
     Value: !Join ['', ['http://', !GetAtt 'PublicLoadBalancer.DNSName']]
     Export:
       Name: !Join [ ':', [ !Ref 'AWS::StackName', 'ExternalUrl' ] ]
-  
-  ECSRole:
-    Description: The ARN of the ECS role
-    Value: !GetAtt 'ECSRole.Arn'
-    Export:
-      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'ECSRole' ] ]
   
   ECSTaskExecutionRole:
     Description: The ARN of the ECS role


### PR DESCRIPTION
Call me stupid, but I don't see where the `ECSRole` is used. 🙈 

I think it could be used with the `PrismaService` (`AWS::ECS::Service`), [as described here](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#iam_role), but this states:
> If using awsvpc network mode, **do not specify this role**.

We are indeed using `awsvpc` network mode.

(Sorry for the Terraform link, I am not using Cloudformation but this should still apply.)


See nathanpeck/aws-cloudformation-fargate#9


---
**PS** I'm rewriting the two cloudformation files from [the guide](https://www.prisma.io/tutorials/deploy-prisma-to-aws-fargate-ct14) in Terraform atm, would you be interested in that or do you not really care?